### PR TITLE
Updated readme with TXS_VERSION=v4.2.9

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ The setup presented here, assumes that only L2 safes will be used. Additionally,
 
 - `CFG_VERSION=v2.12.0`
 - `CGW_VERSION=v3.19.1`
-- `TXS_VERSION=v4.2.8`
+- `TXS_VERSION=v4.2.9`
 
 You can change them to the version you are interested available in [docker-hub](https://hub.docker.com/u/gnosispm) but be aware that not all versions of our services are compatible with each other, so do so **at your own risk.**
 


### PR DESCRIPTION
TXS_VERSION=v4.2.9 fixes and issue where setting the URL field to http://nginx:8000/cgw/v1/chains/1/hooks/events, as described on the instructions results in a "Enter a valid URL" message.