### PR TITLE
Add basic setup script

### DIFF
--- a/docs/running_locally.md
+++ b/docs/running_locally.md
@@ -1,5 +1,13 @@
 # Running our services locally
 
+## (Optionally) Run the automated script
+We provide a script to automate steps 1 and 2, if you want to use it, simply do:
+```
+cd scripts
+sh run_locally.sh
+```
+After this, you can skip steps 1 and 2, and you can go directly to step 3.
+
 ## Step 1: setup your `.env`
 
 We recommend using what is available in the `.env.sample` file as it contains versions of our services guaranteed to be compatible with each other:

--- a/docs/running_locally.md
+++ b/docs/running_locally.md
@@ -1,13 +1,5 @@
 # Running our services locally
 
-## (Optionally) Run the automated script
-We provide a script to automate steps 1 and 2, if you want to use it, simply do:
-```
-cd scripts
-sh run_locally.sh
-```
-After this, you can skip steps 1 and 2, and you can go directly to step 3.
-
 ## Step 1: setup your `.env`
 
 We recommend using what is available in the `.env.sample` file as it contains versions of our services guaranteed to be compatible with each other:
@@ -19,13 +11,20 @@ cp .env.sample .env
 Simply, edit your `.env` and set `RPC_NODE_URL` to the chain you want the services running against.
 **Important Note:** Only L2 safes are supported in the setup provided. Change this at your own risk.
 
-Now you should be able to run
+## Step 2: Setup Django superusers
 
+### Option #1 - Automated way
+We provide a script to automate this second step, if you want to use it, simply write:
+```
+cd scripts
+sh run_locally.sh
+```
+
+### Option #2 - Manual way
+Start Docker containers:
 ```bash
 docker compose up
 ```
-
-## Step 2: Setup Django superusers
 
 You will need to identify the ID or name of the containers using `docker ps`. To create the default super user for the Safe Config Service, we run the following command:
 

--- a/scripts/run_locally.sh
+++ b/scripts/run_locally.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 
+set -e
+
 echo "==> $(date +%H:%M:%S) ==> Setting up environment variables from sample file..."
-TEMP=temp.env
-cp ../.env.sample $TEMP
+TEMP=temp.env \
+  && cp ../.env.sample $TEMP \
+  || exit
 
 echo "==> $(date +%H:%M:%S) ==> Using http://polygon-rpc.com as default RPC node"
-sed -i '' 's|http://url.to.node|https://polygon-rpc.com|g' $TEMP
-mv $TEMP ../.env
+sed -i '' 's|http://url.to.node|https://polygon-rpc.com|g' $TEMP \
+  && mv $TEMP ../.env \
+  || exit
 
 echo "==> $(date +%H:%M:%S) ==> Starting up environment containers..."
 docker compose up -d \
   && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Config Service..." \
   && docker compose exec cfg-web python src/manage.py createsuperuser \
   && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Transaction Service..." \
-  && docker compose exec txs-web python manage.py createsuperuser
+  && docker compose exec txs-web python manage.py createsuperuser \
+  || exit
 
-echo "==> $(date +%H:%M:%S) ==> Adding ChainInfo..."
+echo "==> $(date +%H:%M:%S) ==> All set! You may want to add a ChainInfo into the Config service. Please use the link below to fill its data: "

--- a/scripts/run_locally.sh
+++ b/scripts/run_locally.sh
@@ -20,4 +20,4 @@ docker compose up -d \
   && docker compose exec txs-web python manage.py createsuperuser \
   || exit
 
-echo "==> $(date +%H:%M:%S) ==> All set! You may want to add a ChainInfo into the Config service. Please use the link below to fill its data: "
+echo "==> $(date +%H:%M:%S) ==> All set! You may want to add a ChainInfo into the Config service. Please use the link below to fill its data: http://localhost:8000/cfg/admin/chains/chain/add/"

--- a/scripts/run_locally.sh
+++ b/scripts/run_locally.sh
@@ -2,22 +2,11 @@
 
 set -e
 
-echo "==> $(date +%H:%M:%S) ==> Setting up environment variables from sample file..."
-TEMP=temp.env \
-  && cp ../.env.sample $TEMP \
-  || exit
-
-echo "==> $(date +%H:%M:%S) ==> Using http://polygon-rpc.com as default RPC node"
-sed -i '' 's|http://url.to.node|https://polygon-rpc.com|g' $TEMP \
-  && mv $TEMP ../.env \
-  || exit
-
 echo "==> $(date +%H:%M:%S) ==> Starting up environment containers..."
 docker compose up -d \
-  && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Config Service..." \
+  && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Config Service... (may take a while)" \
   && docker compose exec cfg-web python src/manage.py createsuperuser \
-  && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Transaction Service..." \
-  && docker compose exec txs-web python manage.py createsuperuser \
-  || exit
+  && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Transaction Service... (may take a while)" \
+  && docker compose exec txs-web python manage.py createsuperuser || exit
 
 echo "==> $(date +%H:%M:%S) ==> All set! You may want to add a ChainInfo into the Config service. Please use the link below to fill its data: http://localhost:8000/cfg/admin/chains/chain/add/"

--- a/scripts/run_locally.sh
+++ b/scripts/run_locally.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+echo "==> $(date +%H:%M:%S) ==> Setting up environment variables from sample file..."
+TEMP=temp.env
+cp ../.env.sample $TEMP
+
+echo "==> $(date +%H:%M:%S) ==> Using http://polygon-rpc.com as default RPC node"
+sed -i '' 's|http://url.to.node|https://polygon-rpc.com|g' $TEMP
+mv $TEMP ../.env
+
+echo "==> $(date +%H:%M:%S) ==> Starting up environment containers..."
+docker compose up -d \
+  && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Config Service..." \
+  && docker compose exec cfg-web python src/manage.py createsuperuser \
+  && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Transaction Service..." \
+  && docker compose exec txs-web python manage.py createsuperuser
+
+echo "==> $(date +%H:%M:%S) ==> Adding ChainInfo..."


### PR DESCRIPTION
Closes #4 

This is a very simple script to just start the Docker containers and create the superusers. As we discussed we can stay simple and let the user insert the ChainInfo. I updated the `README.md` file accordingly.