### PR TITLE
docs: fix some document errors

### DIFF
--- a/docs/docker_cheatsheet.md
+++ b/docs/docker_cheatsheet.md
@@ -17,8 +17,8 @@ docker compose build --force-rm
 Accessing `bash` in your web containers can be achieved by:
 
 ```bash
-docker exec -it safe-infrastructure_cfg-web_1 bash
-docker exec -it safe-infrastructure_txs-web_1 bash
+docker compose exec -it cfg-web bash
+docker compose exec -it txs-web bash
 ```
 
 `Ctrl+d` will end interactive mode.
@@ -27,13 +27,14 @@ docker exec -it safe-infrastructure_txs-web_1 bash
 Accessing `redis-cli` in either redis can be achieved like so"
 
 ```bash
-docker exec -it safe-infrastructure_cgw-redis_1 redis-cli
-docker exec -it safe-infrastructure_txs-redis_1 redis-cli
+docker compose exec -it cgw-redis redis-cli
+docker compose exec -it txs-redis redis-cli
 ```
 
 ## Starting psql connected to a container
-Accessing `postgres`. The Safe Config and Safe transaction services share the same instance
+Accessing `postgres`. The Safe Config and Safe transaction services use the different instance
 
 ```bash
-docker exec -it safe-infrastructure_db_1 psql -U postgres
+docker compose exec -it cfg-db psql -U postgres
+docker compose exec -it txs-db psql -U postgres
 ```

--- a/docs/running_locally.md
+++ b/docs/running_locally.md
@@ -37,7 +37,7 @@ You can now access http://localhost:8000/cfg/admin/ and login using the credenti
 To achieve the same for the Safe Transaction service:
 
 ```bash
-docker compose exec txs-web python manage.py createsuperuser --noinput --username root
+docker compose exec txs-web python manage.py createsuperuser --username root
 ```
 
 Note 1: note that the path to `manage.py` is different. In case you need to run other commands.


### PR DESCRIPTION
- Fix CommandError `You must use --email with --noinput.` in docs/running_locally.md
- Fix container name typo in docs/docker_cheatsheet.md
- The Safe Config and Safe transaction services does not share the same instance now
