### PR TITLE
Added new web core frontend

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,5 +4,6 @@ REVERSE_PROXY_UI_PORT=8080
 CFG_VERSION=latest
 CGW_VERSION=latest
 TXS_VERSION=latest
+UI_VERSION=latest
 
 RPC_NODE_URL=http://url.to.node

--- a/container_env_files/ui.env
+++ b/container_env_files/ui.env
@@ -1,29 +1,31 @@
-# Define environment
-REACT_APP_ENV=production
-# For all environments
-REACT_APP_GATEWAY_URL=http://localhost:${REVERSE_PROXY_PORT}/cgw
-REACT_APP_GOOGLE_ANALYTICS=
-REACT_APP_INFURA_TOKEN=
-REACT_APP_IPFS_GATEWAY=https://ipfs.io/ipfs
-REACT_APP_SENTRY_DSN=
-REACT_APP_SAFE_APPS_RPC_INFURA_TOKEN=
-REACT_APP_GNOSIS_APPS_URL=
+### Required variables ###
+NEXT_PUBLIC_INFURA_TOKEN=
+NEXT_PUBLIC_GATEWAY_URL_PRODUCTION=http://localhost:8000/cgw
 
-# For production environments
-REACT_APP_INTERCOM_ID=
-REACT_APP_PORTIS_ID=
-REACT_APP_SQUARELINK_ID=
-REACT_APP_FORTMATIC_KEY=
-REACT_APP_COLLECTIBLES_SOURCE=
-REACT_APP_ETHERSCAN_API_KEY=
-REACT_APP_ETHGASSTATION_API_KEY=
+# infura token used by Safe Apps
+NEXT_PUBLIC_SAFE_APPS_INFURA_TOKEN=
 
-# Versions
-REACT_APP_LATEST_SAFE_VERSION=
+# Transaction simulation
+NEXT_PUBLIC_TENDERLY_SIMULATE_ENDPOINT_URL=
+NEXT_PUBLIC_TENDERLY_PROJECT_NAME=
+NEXT_PUBLIC_TENDERLY_ORG_NAME=
 
-# Leave it untouched, version will set using dotenv-expand
-REACT_APP_APP_VERSION=$npm_package_version
+# Flag to switch to the production environment (redirect urls, gateway url, etc)
+NEXT_PUBLIC_IS_PRODUCTION=true
 
-# Contracts Addresses
-REACT_APP_SPENDING_LIMIT_MODULE_ADDRESS=
+### Optional variables ###
+# These variables are required only if you require a certain feature in the interface (e.g. Portis wallet)
+# Or overwrite the fallback values (set a different WalletConnect bridge)
 
+# Latest supported safe version, used for upgrade prompts
+NEXT_PUBLIC_SAFE_VERSION=1.3.0
+
+# Access keys
+NEXT_PUBLIC_SENTRY_DSN=
+NEXT_PUBLIC_BEAMER_ID=
+
+# Wallet specific variables
+NEXT_PUBLIC_WC_BRIDGE=
+NEXT_PUBLIC_FORTMATIC_KEY=
+NEXT_PUBLIC_PORTIS_KEY=
+NEXT_PUBLIC_CYPRESS_MNEMONIC=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       - cgw-redis
 
   ui:
-    image: safeglobal/web-core
+    image: safeglobal/web-core:${UI_VERSION}
     env_file:
       - container_env_files/ui.env
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
       - cgw-redis
 
   ui:
-    image: safeglobal/safe-react
+    image: safeglobal/web-core
     env_file:
       - container_env_files/ui.env
     depends_on:

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ The setup presented here, assumes that only L2 safes will be used. Additionally,
 - `CFG_VERSION=v2.26.0`
 - `CGW_VERSION=v3.29.0`
 - `TXS_VERSION=v4.6.1`
+- `UI_VERSION=v1.2.0`
 
 You can change them to the version you are interested available in [docker-hub](https://hub.docker.com/u/safeglobal) but be aware that not all versions of our services are compatible with each other, so do so **at your own risk.**
 

--- a/docs/running_locally.md
+++ b/docs/running_locally.md
@@ -84,5 +84,7 @@ The Gnosis Safe Web app will be available at at http://localhost:8080 although c
 
 To configure the port in which the Safe Web app will be reachable, look into our sample [.env](.env.sample) file. The value of `REVERSE_PROXY_UI_PORT` defines this.
 
-Additionally, the Safe Web app itself, defines which instance of the Safe CGW to use in this [container_env_files/ui.env](container_env_files/ui.env) file. The value of `REACT_APP_GATEWAY_URL` defines the URL where the Safe CGW can be reached. The default in this repo, points to the instance running as part of the `docker-compose.yml` file, but can be adjusted to point to our production instances, or your own hosted instance.
+Add your `NEXT_PUBLIC_INFURA_TOKEN` value if its required for the chain RCP uri in the [container_env_files/ui.env](container_env_files/ui.env) file.
+
+Additionally, the Safe Web app itself, defines which instance of the Safe CGW to use in this [container_env_files/ui.env](container_env_files/ui.env) file. The value of `NEXT_PUBLIC_GATEWAY_URL_PRODUCTION` defines the URL where the Safe CGW can be reached. The default in this repo, points to the instance running as part of the `docker-compose.yml` file, but can be adjusted to point to our production instances, or your own hosted instance.
 

--- a/docs/running_locally.md
+++ b/docs/running_locally.md
@@ -80,7 +80,7 @@ For the Transactions service, follow these steps:
 
 # Safe Web App
 
-The Gnosis Safe Web app will be available at at http://localhost:8080 although check the output of `docker compose` to see that the container is already running, as in some step-ups, it can take longer than expected.
+The Safe Web app will be available at at http://localhost:8080 although check the output of `docker compose` to see that the container is already running, as in some step-ups, it can take longer than expected ( >15 minutes).
 
 To configure the port in which the Safe Web app will be reachable, look into our sample [.env](.env.sample) file. The value of `REVERSE_PROXY_UI_PORT` defines this.
 


### PR DESCRIPTION
## What it solves

Resolves safe-global/safe-infrastructure#58

## How this PR fixes it

Added new `web-core` Docker image to use our new UI in [the `docker-compose` file](https://github.com/safe-global/safe-infrastructure/pull/62/files#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R109).

Updated the [`ui.env` file](https://github.com/safe-global/safe-infrastructure/pull/62/files#diff-06cec2c9c8bd6d55e9b8ea23918ab267d6eec562d89100eb587129f88bb133f1) with the new `web-core` env vars.

Updated [docs](https://github.com/safe-global/safe-infrastructure/pull/62/files#diff-6b60c91204cf14e0fe2fc7e80f79fd16aefd832a2bfb049979a1fc6047d99b2eR87).

## How to test it

follow the instructions defined in the docs to add your chain.

Tested in local used `volta` chain testnet.

1. ### Create the env file:
```
cp .env.sample .env
```

with `volta` chain `RPC_NODE_URL` value:

```
REVERSE_PROXY_PORT=8000
REVERSE_PROXY_UI_PORT=8080

CFG_VERSION=latest
CGW_VERSION=latest
TXS_VERSION=latest

RPC_NODE_URL=https://volta-rpc.energyweb.org

```

2.  ### Create Django superusers in the `config-service` & `transaction-service`
build and run containers by executing

```
docker compose up
```
#### Create `config-service` superuser:
```
docker compose exec cfg-web python src/manage.py createsuperuser --noinput
```
Now you can access `http://localhost:8000/cfg/admin/` and login using the credentials :
```
login: root
pass: admin
```

#### Create `transaction-service` superuser:
```
docker compose exec txs-web python manage.py createsuperuser --username root
```
populate email in the terminal: `example@test.test`
populate pass in the terminal: `admin`

Now you can access `http://localhost:8000/txs/admin` and login using the credentials :
```
login: root
pass: admin
```

3.  ### Add The Chain object definition in the `transaction-service` ( it represents metadata specific to your chain)

Access to the `http://localhost:8000/cfg/admin/chains/chain/add/` and login using the credentials (`root/admin`)

Add your chain with this data (we use `volta` chain data as an example)

![Captura de pantalla 2022-12-20 a las 18 23 55](https://user-images.githubusercontent.com/26763673/208728281-df619eb7-f3a1-41f1-a8ae-c5cda4b9c76b.png)
![Captura de pantalla 2022-12-20 a las 18 24 28](https://user-images.githubusercontent.com/26763673/208728284-24b13d2b-c265-44bd-88b3-cd5a116f8809.png)

Note: Remember to edit your `ChainInfo` json fields `transaction_service_uri` and `vpc_transaction_service_uri` to point to your local instance of the transaction service. The values should be `http://nginx:8000/txs`

4. ### Add  Webhooks

Access the admin panel at `http://localhost:8000/txs/admin`,  click the `Add` link for `Web hooks`. Ignore the `Address` field. Set the `Url` field to `http://nginx:8000/cgw/v1/chains/{chainId}/hooks/events` and replace `{chainId}` with the corresponding chainId. Set the `Authorization` field to `Basic <WEBHOOK_TOKEN>`, where `<WEBHOOK_TOKEN>` corresponds to the value of `WEBHOOK_TOKEN` in the `container_env_files/cgw.env` file of this repository (in my case I just keep the `some_random_token` default value):

![Captura de pantalla 2022-12-20 a las 18 44 29](https://user-images.githubusercontent.com/26763673/208731970-53008896-4461-4ce3-bfdb-79d9fe96c909.png)


5. ### tests the UI
The Safe Web app will be available at at `http://localhost:8080`


## Screenshots

![Captura de pantalla 2022-12-20 a las 17 25 51](https://user-images.githubusercontent.com/26763673/208724671-611a4dd4-903f-4172-94e5-715e11d7f903.png)
![Captura de pantalla 2022-12-20 a las 17 25 56](https://user-images.githubusercontent.com/26763673/208724677-532fa43a-499d-4739-a28e-5fe0ea815cde.png)
![Captura de pantalla 2022-12-20 a las 17 26 24](https://user-images.githubusercontent.com/26763673/208724684-b1db5d6c-49cc-4ef8-b4fd-26fe9d91549b.png)
![Captura de pantalla 2022-12-20 a las 17 28 06](https://user-images.githubusercontent.com/26763673/208724687-660dce01-381a-4942-bde1-18d1ff83086d.png)
![Captura de pantalla 2022-12-20 a las 17 29 20](https://user-images.githubusercontent.com/26763673/208724688-8f43c971-c42c-4866-a46e-470ce561ef4b.png)


- [X]  pending from web-core team to merge [the updated Dockerfile PR](https://github.com/safe-global/web-core/pull/1408).
- [x] pending from infra team to deploy the `safeglobal/web-core` image to our `safeglobal` docker hub
- [ x]  Waiting for a `safeglobal/web-core:latest` image.

![Captura de pantalla 2022-12-23 a las 15 07 22](https://user-images.githubusercontent.com/26763673/209351889-f3cbff22-be6d-43eb-8902-490fca0dec47.png)
