### PR TITLE
Add environment ETHEREUM_NODE_URL to contract and notification workers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,11 +73,13 @@ services:
     <<: *txs-worker
     environment:
       - WORKER_QUEUES=contracts,tokens
+      - ETHEREUM_NODE_URL=${RPC_NODE_URL}
 
   txs-worker-notifications-webhooks:
     <<: *txs-worker
     environment:
       - WORKER_QUEUES=notifications,webhooks
+      - ETHEREUM_NODE_URL=${RPC_NODE_URL}
 
   txs-scheduler:
     <<: *txs-worker


### PR DESCRIPTION
Fix #66 by set enviroment `ETHEREUM_NODE_URL` for service `txs-worker-contracts-tokens` and `txs-worker-notifications-webhooks` in file `docker-compose.yml`. Otherwise ETHEREUM_NODE_URL is not set for these two service without this PR. Use command `docker compose config` to  print enviroments.