### PR TITLE
Add sleep to wait for migrations

### DIFF
--- a/scripts/run_locally.sh
+++ b/scripts/run_locally.sh
@@ -4,6 +4,8 @@ set -e
 
 echo "==> $(date +%H:%M:%S) ==> Starting up environment containers..."
 docker compose up -d \
+  && echo "==> $(date +%H:%M:%S) ==> Waiting for migrations... (may take a while)" \
+  && sleep 60 \
   && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Config Service... (may take a while)" \
   && docker compose exec cfg-web python src/manage.py createsuperuser \
   && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Transaction Service... (may take a while)" \


### PR DESCRIPTION
Closes #72 
## Description
Migrations take some time and run_locally script executes createsuperuser before migrations ready and throws an error. 
```
==> 06:05:00 ==> Creating super-user for Safe Config Service... (may take a while)
2023-02-23 06:05:03,339 [DEBUG] [MainProcess] Consider installing rusty-rlp to improve pyrlp performance with a rust based backend

You have 64 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin, auth, chains, contenttypes, safe_apps, sessions.
Run 'python manage.py migrate' to apply them.
Traceback (most recent call last):
  File "/python-deps/lib/python3.10/site-packages/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.UndefinedTable: relation "auth_user" does not exist
LINE 1: ...user"."is_active", "auth_user"."date_joined" FROM "auth_user...
  
```
This PR add a sleep to wait at least 60 seconds to ensure that migrations were done. 