### PR TITLE
fix: compose issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -161,6 +161,8 @@ services:
       - nginx
     ports:
       - "${REVERSE_PROXY_UI_PORT}:8080"
+    command: >
+      sh -c "yarn after-install && yarn static-serve"
 
   general-rabbitmq:
     image: rabbitmq:alpine

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -132,6 +132,19 @@ http {
             proxy_set_header X-Forwarded-Host $server_name;
             proxy_set_header X-Real-IP $remote_addr;
             add_header              Front-End-Https   on;
+            if ($request_method = 'OPTIONS') {
+              add_header 'Access-Control-Allow-Origin' '*';
+              add_header 'Access-Control-Allow-Headers' 'DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization';
+              add_header 'Access-Control-Allow-Methods' 'OPTIONS, GET, HEAD, DELETE';
+              add_header 'Access-Control-Max-Age' 1728000;
+              add_header 'Content-Type' 'text/plain; charset=utf-8';
+              add_header 'Content-Length' 0;
+              return 204;
+            }
+            add_header 'Access-Control-Allow-Origin' '*' always;
+            add_header 'Access-Control-Allow-Credentials' 'true' always;
+            add_header 'Access-Control-Allow-Headers' 'DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization' always;
+            add_header 'Access-Control-Allow-Methods' 'OPTIONS, GET, HEAD, DELETE' always;
         }
       
       ## Events service mounting point


### PR DESCRIPTION
I had problems running docker-compose in my MAC and i solved problems with these changes.

1. ui service change: for some reason, safe-wallet-web image has no contract types generated. (afterinstall is failing). I have adapted the command the fix the issue. (https://github.com/safe-global/safe-wallet-web/issues/2656)
2. As cgw and ui are using different ports and cgw has no enabled cors, i couldnt use compose without setting cors headers for the cgw. (in a different setup for production this might not be a problem so i dont create issue for this nginx change in cgw repo)