### PR TITLE
Increase number of docker max connections to 250

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
 
   txs-db:
     image: postgres:14-alpine
+    command: -c 'max_connections=250'
     environment:
       POSTGRES_PASSWORD: postgres
     volumes:


### PR DESCRIPTION
- Quickly a `OperationalError: FATAL: sorry, too many clients already using` was triggered.
- Postgres configures by default max connections to 100.
- Every python web/worker opens 50 connections to the database: web, worker-indexer, worker-tokens and worker-notifications. Total: 200.
