### PR TITLE
Change EMAIL_API_FROM_EMAIL example value

### DIFF
--- a/container_env_files/cgw.env
+++ b/container_env_files/cgw.env
@@ -41,6 +41,6 @@ ALERTS_PROVIDER_PROJECT=''
 # Please note that the Safe CGW is currently using Pushwoosh as the email services provider.
 # Refer to the provider's official documentation to set up emailing.
 EMAIL_API_APPLICATION_CODE=''
-EMAIL_API_FROM_EMAIL=ch@nge.me
+EMAIL_API_FROM_EMAIL=changeme@example.com
 EMAIL_API_KEY=''
 EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX=''


### PR DESCRIPTION
Changes:
- Uses an example.com email domain for the `EMAIL_API_FROM_EMAIL` example value.

(Thanks to @fmrsabino for the suggestion here: https://github.com/safe-global/safe-client-gateway/pull/942#discussion_r1427740854)