### PR TITLE
CGW - Add Relay configuration placeholders

### DIFF
--- a/container_env_files/cgw.env
+++ b/container_env_files/cgw.env
@@ -37,6 +37,10 @@ ALERTS_PROVIDER_API_KEY=''
 ALERTS_PROVIDER_ACCOUNT=''
 ALERTS_PROVIDER_PROJECT=''
 
+# Relay Provider
+RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN=''
+RELAY_PROVIDER_API_KEY_SEPOLIA=''
+
 # Email handling
 # Please note that the Safe CGW is currently using Pushwoosh as the email services provider.
 # Refer to the provider's official documentation to set up emailing.


### PR DESCRIPTION
## Changes:
- Adds placeholders for the relay provider mandatory configuration params.

## Additional context:
These values are added to the main CGW configuration file just as placeholders (`''`) as we have in place for the `Alerts provider` configuration for example. Nevertheless, this might be a temporal solution while we don't have a per-module configuration validator.