### PR TITLE
Fix Tx Service migrations execution dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,22 +72,6 @@ services:
   txs-rabbitmq:
     image: rabbitmq:alpine
 
-  txs-web:
-    image: safeglobal/safe-transaction-service:${TXS_VERSION}
-    env_file:
-      - container_env_files/txs.env
-    environment:
-      - ETHEREUM_NODE_URL=${RPC_NODE_URL}
-    depends_on:
-      txs-db:
-        condition: service_healthy
-      txs-redis:
-        condition: service_healthy
-    working_dir: /app
-    volumes:
-      - nginx-shared-txs:/nginx
-    command: docker/web/run_web.sh
-
   txs-worker-indexer: &txs-worker
     image: safeglobal/safe-transaction-service:${TXS_VERSION}
     env_file:
@@ -121,6 +105,20 @@ services:
     depends_on:
       txs-worker-indexer:
         condition: service_healthy
+
+  txs-web:
+    image: safeglobal/safe-transaction-service:${TXS_VERSION}
+    env_file:
+      - container_env_files/txs.env
+    environment:
+      - ETHEREUM_NODE_URL=${RPC_NODE_URL}
+    depends_on:
+      txs-worker-indexer:
+        condition: service_healthy
+    working_dir: /app
+    volumes:
+      - nginx-shared-txs:/nginx
+    command: docker/web/run_web.sh
 
   txs-scheduler:
     <<: *txs-worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,13 @@ x-healthcheck-redis-template: &redishealthcheck
     timeout: 30s
     retries: 3
 
+x-healthcheck-celery-template: &celeryhealthcheck
+  healthcheck:
+    test: ["CMD", "celery", "inspect", "ping"]
+    interval: 30s
+    timeout: 30s
+    retries: 3
+
 services:
   # Common nginx and database
   nginx:
@@ -95,6 +102,7 @@ services:
       txs-redis:
         condition: service_healthy
     command: docker/web/celery/worker/run.sh
+    <<: *celeryhealthcheck
 
   txs-worker-contracts-tokens:
     <<: *txs-worker
@@ -102,9 +110,7 @@ services:
       - WORKER_QUEUES=contracts,tokens
       - ETHEREUM_NODE_URL=${RPC_NODE_URL}
     depends_on:
-      txs-db:
-        condition: service_healthy
-      txs-redis:
+      txs-worker-indexer:
         condition: service_healthy
 
   txs-worker-notifications-webhooks:
@@ -113,9 +119,7 @@ services:
       - WORKER_QUEUES=notifications,webhooks
       - ETHEREUM_NODE_URL=${RPC_NODE_URL}
     depends_on:
-      txs-db:
-        condition: service_healthy
-      txs-redis:
+      txs-worker-indexer:
         condition: service_healthy
 
   txs-scheduler:

--- a/scripts/run_locally.sh
+++ b/scripts/run_locally.sh
@@ -4,8 +4,6 @@ set -e
 
 echo "==> $(date +%H:%M:%S) ==> Starting up environment containers..."
 docker compose up -d \
-  && echo "==> $(date +%H:%M:%S) ==> Waiting for migrations... (may take a while)" \
-  && sleep 60 \
   && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Config Service... (may take a while)" \
   && docker compose exec cfg-web python src/manage.py createsuperuser \
   && echo "==> $(date +%H:%M:%S) ==> Creating super-user for Safe Transaction Service... (may take a while)" \


### PR DESCRIPTION
Closes: https://github.com/safe-global/safe-infrastructure/issues/135

To start the txs-worker-notifications-webhooks and txs-worker-contracts-tokens services is needed the database ready and with the migrations executed. 

For this, a Celery healthcheck validation is added in the service that executes the migrations. Celery is executed once the migrations are finished.

Then the dependent services are started when the Celery healthcheck is ok.