### PR TITLE
Update CGW startup environment variables

### DIFF
--- a/container_env_files/cgw.env
+++ b/container_env_files/cgw.env
@@ -5,10 +5,9 @@ HTTP_CLIENT_REQUEST_TIMEOUT_MILLISECONDS=60000
 # The base url for the Safe Config Service
 SAFE_CONFIG_BASE_URI=http://nginx:8000/cfg
 
-# Exchange Rates
-# The base Exchange Rate API to be used.
-EXCHANGE_API_BASE_URI=http://api.exchangeratesapi.io/v1
-EXCHANGE_API_KEY=your_exchange_rate_api_token
+# RPC Provider
+# The RPC provider to be used.
+INFURA_API_KEY=''
 
 # Redis
 # The host name of where the Redis instance is running
@@ -37,10 +36,6 @@ ALERTS_PROVIDER_API_KEY=''
 ALERTS_PROVIDER_ACCOUNT=''
 ALERTS_PROVIDER_PROJECT=''
 
-# Relay Provider
-RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN=''
-RELAY_PROVIDER_API_KEY_SEPOLIA=''
-
 # Email handling
 # Please note that the Safe CGW is currently using Pushwoosh as the email services provider.
 # Refer to the provider's official documentation to set up emailing.
@@ -50,3 +45,14 @@ EMAIL_API_KEY=''
 EMAIL_TEMPLATE_RECOVERY_TX=''
 EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX=''
 EMAIL_TEMPLATE_VERIFICATION_CODE=''
+
+# Relay Provider
+# The relay provider to be used.
+# (default='https://api.gelato.digital')
+# RELAY_PROVIDER_API_BASE_URI=
+# (default=5)
+# RELAY_THROTTLE_LIMIT=
+# The API key to be used per chain.
+RELAY_PROVIDER_API_KEY_ARBITRUM_ONE=''
+RELAY_PROVIDER_API_KEY_GNOSIS_CHAIN=''
+RELAY_PROVIDER_API_KEY_SEPOLIA=''


### PR DESCRIPTION
## Changes
- Add `INFURA_API_KEY` CGW configuration placeholder.
- Add `RELAY_PROVIDER_API_KEY_ARBITRUM_ONE` CGW configuration placeholder.
- Remove `EXCHANGE_API_BASE_URI` and `EXCHANGE_API_KEY` CGW configuration placeholders (not used anymore by the service).