### PR TITLE
Add env. vars. for CGW push notifications

### DIFF
--- a/container_env_files/cgw.env
+++ b/container_env_files/cgw.env
@@ -46,6 +46,17 @@ EMAIL_TEMPLATE_RECOVERY_TX=''
 EMAIL_TEMPLATE_UNKNOWN_RECOVERY_TX=''
 EMAIL_TEMPLATE_VERIFICATION_CODE=''
 
+# Push Notifications Provider
+# The Safe CGW uses Firebase Cloud Message to dispatch push notifications.
+# Please refer to the provider's official documentation for configuration.
+# (default=https://fcm.googleapis.com/v1/projects)
+# PUSH_NOTIFICATIONS_API_BASE_URI=
+# Firebase project
+PUSH_NOTIFICATIONS_API_PROJECT=''
+# Firebase service account details for authenticating with Google
+PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL=''
+PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY=''
+
 # Relay Provider
 # The relay provider to be used.
 # (default='https://api.gelato.digital')


### PR DESCRIPTION
## Summary

In accordance with [the implementation of Firebase](https://github.com/safe-global/safe-client-gateway/pull/1767#discussion_r1680830734) to the CGW, this adds the required env. vars. for push notifications.

## Changes

- Add example env. vars.:
  - `PUSH_NOTIFICATIONS_API_BASE_URI` (defaulted)
  - `PUSH_NOTIFICATIONS_API_PROJECT`
  - `PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_CLIENT_EMAIL`
  - `PUSH_NOTIFICATIONS_API_SERVICE_ACCOUNT_PRIVATE_KEY`