### PR TITLE
Add nginx shared media volume and configure media location.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 volumes:
   nginx-shared-txs:
   nginx-shared-cfg:
+  nginx-shared-media:
 
 x-healthcheck-db-template: &pghealthcheck
   healthcheck:
@@ -33,6 +34,7 @@ services:
       - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
       - nginx-shared-txs:/nginx-txs
       - nginx-shared-cfg:/nginx-cfg
+      - nginx-shared-media:/cfg-media
     depends_on:
       - txs-web
       - cfg-web
@@ -143,6 +145,7 @@ services:
     tty: true
     volumes:
       - nginx-shared-cfg:/nginx
+      - nginx-shared-media:/app/src/media
     env_file:
       - container_env_files/cfg.env
     depends_on:

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -112,6 +112,11 @@ http {
             expires 365d;
         }
 
+        location /cfg/media {
+            alias /cfg-media;
+            expires 365d;
+        }
+
         location /cfg/ {
             proxy_set_header Host $host;
             proxy_set_header X-Forwarded-Host $server_name;


### PR DESCRIPTION
This fixes an issue when accessing/saving the cfg assets and stores the media assets in a volume making the assets persist when the container changes.
Works with the default configuration. 

fixes #174